### PR TITLE
Fixing the code to comply with extensions manifest V2

### DIFF
--- a/clipperz-chrome-extension/html/background.html
+++ b/clipperz-chrome-extension/html/background.html
@@ -80,13 +80,6 @@
     <script src="/js/Clipperz/PM/UI/Extensions/Chrome/Controllers/BackgroundLoginController.js"></script>
 
     <script src="/js/Clipperz/PM/UI/Extensions/Chrome/main.js"></script>
-    <script>
-        Clipperz_IEisBroken = false;
-        Clipperz_normalizedNewLine = '\n';
-        Clipperz_dumpUrl = "/dump/";
-
-        Clipperz.PM.Proxy.defaultProxy = new Clipperz.PM.Proxy.JSON({'url':'https://www.clipperz.com/gamma/json', 'shouldPayTolls':true});
-    </script>
 </head>
 <body>
     <textarea rows="100" cols="100" id="clipboardholder" style="display: none"></textarea>

--- a/clipperz-chrome-extension/html/options.html
+++ b/clipperz-chrome-extension/html/options.html
@@ -40,11 +40,6 @@
     
     <script src="/js/Clipperz/PM/UI/Extensions/Chrome/options.js"></script>
 
-    <script>
-        Clipperz_IEisBroken = false;
-        Clipperz_normalizedNewLine = '\n';
-        Clipperz_dumpUrl = "/dump/";
-    </script>
 </head>
 <body>
     <div id="mainDiv">

--- a/clipperz-chrome-extension/html/popup.html
+++ b/clipperz-chrome-extension/html/popup.html
@@ -84,11 +84,6 @@
     
     <script src="/js/Clipperz/PM/UI/Extensions/Chrome/popup.js"></script>
 
-    <script>
-        Clipperz_IEisBroken = false;
-        Clipperz_normalizedNewLine = '\n';
-        Clipperz_dumpUrl = "/dump/";
-    </script>
 </head>
 <body>
     <div id="mainDiv">

--- a/clipperz-chrome-extension/js/Clipperz/PM/UI/Extensions/Chrome/main.js
+++ b/clipperz-chrome-extension/js/Clipperz/PM/UI/Extensions/Chrome/main.js
@@ -55,3 +55,10 @@ function run() {
 }
 
 MochiKit.DOM.addLoadEvent(run);
+
+// moved from background.html
+Clipperz_IEisBroken = false;
+Clipperz_normalizedNewLine = '\n';
+Clipperz_dumpUrl = "/dump/";
+
+Clipperz.PM.Proxy.defaultProxy = new Clipperz.PM.Proxy.JSON({'url':'https://www.clipperz.com/gamma/json', 'shouldPayTolls':true});

--- a/clipperz-chrome-extension/js/Clipperz/PM/UI/Extensions/Chrome/options.js
+++ b/clipperz-chrome-extension/js/Clipperz/PM/UI/Extensions/Chrome/options.js
@@ -56,3 +56,8 @@ function run() {
 }
 
 MochiKit.DOM.addLoadEvent(run);
+
+// moved from inline options.html
+Clipperz_IEisBroken = false;
+Clipperz_normalizedNewLine = '\n';
+Clipperz_dumpUrl = "/dump/";

--- a/clipperz-chrome-extension/js/Clipperz/PM/UI/Extensions/Chrome/popup.js
+++ b/clipperz-chrome-extension/js/Clipperz/PM/UI/Extensions/Chrome/popup.js
@@ -56,3 +56,8 @@ function run() {
 }
 
 MochiKit.DOM.addLoadEvent(run);
+
+// moved from popup.html
+Clipperz_IEisBroken = false;
+Clipperz_normalizedNewLine = '\n';
+Clipperz_dumpUrl = "/dump/";

--- a/clipperz-chrome-extension/manifest.json
+++ b/clipperz-chrome-extension/manifest.json
@@ -12,7 +12,6 @@
 	"browser_action": {
 		"default_icon": "images/icon.png",
 		"default_title": "__MSG_extension_browser_action_title__",
-		// "popup": "html/popup.html"
 		"default_popup": "html/popup.html"
 	},
 	"background": { "page": "html/background.html" },

--- a/clipperz-chrome-extension/manifest.json
+++ b/clipperz-chrome-extension/manifest.json
@@ -1,6 +1,7 @@
 {
 	"name": "__MSG_extension_name__",
 	"version": "1.0",
+	"manifest_version": 2,
 	"description": "__MSG_extension_description__",
 	"icons": {
 		"16": "images/icon16.png",
@@ -11,11 +12,11 @@
 	"browser_action": {
 		"default_icon": "images/icon.png",
 		"default_title": "__MSG_extension_browser_action_title__",
-		"popup": "html/popup.html"
+		// "popup": "html/popup.html"
+		"default_popup": "html/popup.html"
 	},
 	"background": { "page": "html/background.html" },
 	"homepage_url": "https://www.clipperz.com",
 	"options_page": "html/options.html",
-	"permissions": ["chrome://favicon/", "https://www.clipperz.com/*", "clipboardWrite"],
-	"manifest_version": 2
+	"permissions": ["chrome://favicon/", "https://www.clipperz.com/*", "clipboardWrite"]
 }

--- a/clipperz-chrome-extension/manifest.json
+++ b/clipperz-chrome-extension/manifest.json
@@ -13,8 +13,9 @@
 		"default_title": "__MSG_extension_browser_action_title__",
 		"popup": "html/popup.html"
 	},
-	"background_page": "html/background.html",
+	"background": { "page": "html/background.html" },
 	"homepage_url": "https://www.clipperz.com",
 	"options_page": "html/options.html",
-	"permissions": ["chrome://favicon/", "https://www.clipperz.com/*", "clipboardWrite"]
+	"permissions": ["chrome://favicon/", "https://www.clipperz.com/*", "clipboardWrite"],
+	"manifest_version": 2
 }

--- a/clipperz-chrome-extension/readme.txt
+++ b/clipperz-chrome-extension/readme.txt
@@ -9,3 +9,12 @@ To verify that extension works use this steps (as per http://code.google.com/chr
 To archive extension for deployment you can simply use Google Chrome.
 Open extensions management page in Developer mode as described above and click "Pack extension" button.
 Please refer this link for details: http://code.google.com/chrome/extensions/packaging.html.
+
+Usage
+=====
+Please go to extension Options (right-click on the extension icon in the toolbar and select Options) and enter Nested Labels Separator.
+For example: if this separator is set to "\" (without quotes) and your entry title is "Folder\Title" your entry will show up as
+
+Folder
+  |
+  +-Title


### PR DESCRIPTION
Later Chrome versions complain that the manifest version 1 is deprecated.
I've updated the manifest to version 2 and moved inline scripts to .js code files (options and main) as inline scripts are not allowed.
I still see no extension UI but debugging shows that the credentials do get stored in the local storage and my Clipperz accounts are loaded.
